### PR TITLE
WIP: Add thumbnail extraction

### DIFF
--- a/scripts/thumbnails/Dockerfile
+++ b/scripts/thumbnails/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get install -y ffmpeg
 # Install AWS cli
 RUN pip install awscli
 
+ENV LC_ALL C.UTF-8
+
 # Put executable script at root
-COPY run /root/
-RUN chmod +x /root/run
-ENTRYPOINT ["/root/run"]
+COPY extract-thumbnails /root/
+RUN chmod +x /root/extract-thumbnails
+ENTRYPOINT ["/root/extract-thumbnails"]

--- a/scripts/thumbnails/extract-thumbnails
+++ b/scripts/thumbnails/extract-thumbnails
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Needed environment variables:
+# VIDEO_ID: The YouTube video id to target
+# AWS_ACCESS_KEY_ID: AWS Access Key
+# AWS_SECRET_ACCESS_KEY: AWS Secret Access Key
+# TALKSEARCH_MODE: If set to 'dev', created files will be chown to 1000
+
+# TODO:
+#   Stop if thumbnails already in S3
+
+# Work in /tmp/{VIDEO_ID}
+base_dir="/tmp/talksearch/$VIDEO_ID"
+mkdir -p "$base_dir"
+cd "$base_dir"
+
+# Download the video
+youtube-dl \
+  --restrict-filenames \
+  --output "video.mp4" \
+  --format 133 \
+  --continue \
+  "$VIDEO_ID"
+
+# Extract one thumbnail for every minute of video
+ffmpeg \
+  -i "video.mp4" \
+  -vf fps=1/60 \
+  "%d.jpg"
+
+# When in dev, we change the owner of the files mounted on the host so it's
+# easier to delete them
+if [[ $TALKSEARCH_MODE == 'dev' ]]; then
+  chown 1000:1000 -R /tmp/talksearch/
+fi
+
+# Push thumbnails to S3
+aws s3 \
+  cp . \
+  "s3://alg-talksearch/thumbnails/${VIDEO_ID}/" \
+  --recursive \
+  --exclude "*" --include "*.jpg"

--- a/scripts/thumbnails/run
+++ b/scripts/thumbnails/run
@@ -1,43 +1,25 @@
 #!/usr/bin/env sh
+set -e
 
-# Needed environment variables:
-# VIDEO_ID: The YouTube video id to target
-# AWS_ACCESS_KEY_ID: AWS Access Key
-# AWS_SECRET_ACCESS_KEY: AWS Secret Access Key
+IMAGE_NAME="talksearch"
+CONTAINER_NAME="talksearch"
+VIDEO_ID=$1
 
-# TODO:
-#   Stop if thumbnails already in S3
+mkdir -p /tmp/docker
 
-# Work in /tmp/{VIDEO_ID}
-cd /tmp
-mkdir -p "talksearch/$VIDEO_ID"
-cd "./talksearch/$VIDEO_ID"
+# Create image
+echo "CREATE IMAGE"
+docker build -t $IMAGE_NAME .
 
-# Download the video
-youtube-dl \
-  --output "video.mp4" \
-  --format 133 \
-  --continue \
-  "$VIDEO_ID"
+# Delete previous container
+echo "DELETE CONTAINER"
+docker rm --force $CONTAINER_NAME
 
-# Extract one thumbnail for every minute of video
-ffmpeg \
-  -i "video.mp4" \
-  -vf fps=1/60 \
-  "%d.jpg"
-
-# Push thumbnails to S3
-aws s3 \
-  cp . \
-  "s3://talksearch/thumbnails/${VIDEO_ID}/" \
-  --recursive \
-  --include "*.jpg"
-# video_id="$1"
-# bucket_name="pixelastic-talksearch"
-# path_tmp="/tmp/talksearch"
-# path_destination="${path_tmp}/${video_id}"
-
-
-
-## Push all thumbnails to S3, under the videoId directory
-
+# Run container
+echo "RUN CONTAINER"
+docker run \
+  --name $CONTAINER_NAME \
+  -v /tmp/docker:/tmp \
+  -e TALKSEARCH_MODE='dev' \
+  -e VIDEO_ID="$VIDEO_ID" \
+  $IMAGE_NAME


### PR DESCRIPTION
This PR contains a WIP code that can generate thumbnails at specific interval in videos we extract.

It is packaged as a Docker image for ease of use, and could be used in a kubernetes cluster easily. The idea is to download a youtube video on disk (using `youtube-dl`, and downloading only a low definition one), then extracting thumbnails every `n` seconds (here, every minute) using `ffmpeg`, then pushing the generated thumbnails to S3.

Once this is done, we'll be able to guess which thumbnail to display for each matching record based on its `startTime`. This will greatly improve the way results are displayed, because even the thumbnail will now be relevant to the result, and not just a generic thumbnail.